### PR TITLE
fix import and type problem

### DIFF
--- a/oasis/functions.py
+++ b/oasis/functions.py
@@ -150,6 +150,10 @@ def deconvolve(y, g=(None,), sn=None, b=None, b_nonneg=True,
     lam: float
         Optimal Lagrange multiplier for noise constraint under L1 penalty
     """
+    if np.can_cast(y.dtype,np.double,casting="safe"):
+        y = y.astype(np.double)
+    else:
+        raise TypeError("Input trace should be a np.double")
 
     if g[0] is None or sn is None:
         fudge_factor = .97 if (optimize_g and len(g) == 1) else .98

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,12 @@
 
 from Cython.Build import cythonize
 import numpy as np
+import os
 from setuptools.extension import Extension
 from setuptools import find_packages, setup
+
+os.environ["CC"] = "g++-10"
+os.environ["CXX"] = "g++-10"
 
 with open('requirements.txt', 'r') as f:
     required = f.read().splitlines()


### PR DESCRIPTION
Hello,

Thanks for this great repo. I encountered to problem while using it and thought it could help other users. 
This pull request  fix two things:

- an import error, if the module is compiled with gcc11. The fix specify the use of gcc10 for  cython.
`ImportError: /home/bouromain/miniconda3/envs/env1/lib/python3.8/site-packages/oasis/oasis_methods.cpython-38-x86_64-linux-gnu.so: undefined symbol: _ZSt28__throw_bad_array_new_lengthv`
see  [cython issue](https://github.com/cython/cython/issues/4218#issue-916283113)

- a type error if the input is not a double. 

Hope this will help