### PR TITLE
Transition to pyproject.toml; pin numpy > 2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include oasis/*.pyx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include oasis/*.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,6 @@ build = [
 [build-system]
 requires = ['setuptools', 'wheel', 'Cython', 'numpy>2']
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+oasis = ["*.pyx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "oasis-deconv"
+version = "0.2.0"
+description = "Fast algorithm for deconvolution of neural calcium imaging traces"
+authors = [
+    {name="Johannes Friedrich", email="johannes.friedrich@alleninstitute.org"},
+]
+readme = "README.md"
+requires-python = ">=3.5, <=3.13"
+dependencies = [
+    'numpy',
+    'scipy',
+    'matplotlib',
+    'Cython'
+]
+
+[project.optional-dependencies]
+comparison = [
+    'cvxpy>=0.3.6',
+    'gurobi>=6.5.0',
+    'mosek>=7'
+    ]
+
+
+[build-system]
+requires = ['setuptools', 'wheel', 'Cython', 'numpy>2']
+build-backend = "setuptools.build_meta"
+include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     'numpy',
     'scipy',
     'matplotlib',
-    'Cython'
 ]
 
 [project.optional-dependencies]
@@ -20,9 +19,13 @@ comparison = [
     'gurobi>=6.5.0',
     'mosek>=7'
     ]
-
+build = [
+'setuptools',
+'wheel',
+'Cython',
+'numpy > 2'
+]
 
 [build-system]
 requires = ['setuptools', 'wheel', 'Cython', 'numpy>2']
 build-backend = "setuptools.build_meta"
-include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
 [project.optional-dependencies]
 comparison = [
     'cvxpy>=0.3.6',
-    'gurobi>=6.5.0',
-    'mosek>=7'
+    'ecos'
     ]
 build = [
 'setuptools',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ authors = [
     {name="Johannes Friedrich", email="johannes.friedrich@alleninstitute.org"},
 ]
 readme = "README.md"
-requires-python = ">=3.5, <=3.13"
+requires-python = ">=3.7, <=3.13"
 dependencies = [
-    'numpy',
+    'numpy > 2',
     'scipy',
     'matplotlib',
 ]
@@ -19,14 +19,13 @@ comparison = [
     'ecos'
     ]
 build = [
-'setuptools',
-'wheel',
-'Cython',
-'numpy > 2'
+    'setuptools',
+    'Cython',
+    'numpy > 2'
 ]
 
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython', 'numpy>2']
+requires = ['setuptools', 'Cython', 'numpy > 2']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-data]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-scipy
-matplotlib
-Cython

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -7,30 +7,12 @@ import numpy as np
 from setuptools.extension import Extension
 from setuptools import find_packages, setup
 
-with open('requirements.txt', 'r') as f:
-    required = f.read().splitlines()
-
-with open('test_requirements.txt', 'r') as f:
-    test_required = f.read().splitlines()
-
-with open('README.md', 'r') as f:
-    long_description = f.read()
 
 ext_modules = [Extension("oasis.oasis_methods",
                          sources=["oasis/oasis_methods.pyx"],
                          include_dirs=[np.get_include()],
                          language="c++")]
 
-setup(name='oasis',
-      version='0.2.0',
-      author='Johannes Friedrich',
-      author_email='johannes.friedrich@alleninstitute.org',
-      url='https://github.com/j-friedrich/OASIS',
-      license='GPL-3',
-      description='Fast algorithm for deconvolution of neural calcium imaging traces',
-      long_description=long_description,
-      long_description_content_type='text/markdown',
+setup(name='oasis.oasis_methods',
       ext_modules=cythonize(ext_modules,compiler_directives={'cdivision': True}),
-      packages=find_packages(),
-      install_requires=required,
-      tests_require=test_required)
+)

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 # run with:         python setup.py build_ext -i
 # clean up with:    python setup.py clean --all
 
-from Cython.Build import cythonize
 import numpy as np
 from setuptools.extension import Extension
 from setuptools import find_packages, setup
+from Cython.Build import cythonize
 
 
 ext_modules = [Extension("oasis.oasis_methods",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,0 @@
-cvxpy
-ecos
-nose2


### PR DESCRIPTION
I ran into an issue integrating oasis into our processing pipeline as we use `numpy > 2`. This caused issues when importing oasis as the `PyPa` oasis wheels were built against `numpy < 2`

To approach automatic wheel building for our use case, and to make the package compliant with [PEP 518](https://peps.python.org/pep-0518/) and [PEP 621](https://peps.python.org/pep-0621/), I moved most of the information out of `setup.py` into `pyproject.yaml`. I also pinned `numpy > 2` so the wheels will be built against the newest headers and make oasis compatible with newer code. `setup.py` is still required for building the extension, as the `pyproject.toml` spec only has experimental support for building extensions, and I didn't want to stray too far from the known working build environment.

An additional note is that `cvxpy==1.6` typically gets pulled during the install. This generates some warning messages about depreciated syntax as of version <1.1, but the code still appears to work as intended.

All Github CI builds succeed, and my local runs of the provided test code succeed without issue. I am able to build the package using PyPa `build` and Astral's `uv build` both of which invoke `setuptools`. The resultant wheel then is installable with no errors and oasis can be imported successfully.

Using `pip install -e .` (which automatically builds extensions) succeeds. Further, manually building with `python setup.py build_ext -i` and then running `pip install .` also works. 

I figured I would share these changes with you in case you were interested in applying them to the main repository.

Cheers!
Austin
Dewan Lab
Florida State University


