### PR TITLE
Patch to ensure compatibility with all versions of scipy

### DIFF
--- a/oasis/functions.py
+++ b/oasis/functions.py
@@ -814,8 +814,8 @@ def estimate_time_constant(y, p=2, sn=None, lags=10, fudge_factor=1., nonlinear_
             return np.array([d + r, -d * r])
 
     xc = xc[:, np.newaxis]
-    A = scipy.linalg.toeplitz(xc[np.arange(lags)],
-                              xc[np.arange(p)]) - sn**2 * np.eye(lags, p)
+    A = scipy.linalg.toeplitz(np.ravel(xc[np.arange(lags)]),
+                              np.ravel(xc[np.arange(p)])) - sn**2 * np.eye(lags, p)
     g = np.linalg.lstsq(A, xc[1:], rcond=None)[0]
     gr = np.roots(np.concatenate([np.array([1]), -g.flatten()]))
     gr = (gr + gr.conjugate()) / 2.


### PR DESCRIPTION
In newer versions of scipy (1.17 onwards), scipy.linalg.toeplitz provides explicit batching support to multidimensional inputs. If you pass in a (10, 1)-shaped row matrix and a (10, 1)-shaped column matrix, the output will be (10, 1, 1) (here, the batching dimension is 0). In older versions, scipy.linalg.toeplitz would ravel these inputs for you and produce the desired shape of (10, 10). This shape mismatch breaks the OASIS code for scipy>=1.17. 

This PR ravels the inputs to scipy.linalg.toeplitz to ensure consistency across scipy versions and avoid this error. 